### PR TITLE
Add authorization to design controller

### DIFF
--- a/backend/Atelje/Controllers/DesignController.cs
+++ b/backend/Atelje/Controllers/DesignController.cs
@@ -1,6 +1,6 @@
 using Atelje.DTOs.Design;
 using Atelje.Services;
-// using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Atelje.Controllers;
@@ -8,7 +8,7 @@ namespace Atelje.Controllers;
 
 [ApiController]
 [Route("api/[controller]")]
-// [Authorize]
+[Authorize]
 public class DesignController(IDesignService designService) : ControllerBase
 {
     [HttpGet(Name = "GetAllDesigns")]


### PR DESCRIPTION
No fix required! Only needed to understand scalar better. Add back the temporarily removed authorization in design controller.

While testing in scalar, add header like this with your own token.
| Key | Value |
|-----|-------|
| Authorization | `Bearer <your_jwt_token>` |