### PR TITLE
Fix enableRotate to be connected to only drag frame not select frame

### DIFF
--- a/frontend/src/features/designer/Canvas3D/Canvas3D.tsx
+++ b/frontend/src/features/designer/Canvas3D/Canvas3D.tsx
@@ -35,6 +35,7 @@ const cameraDistance = Math.max(5, floorSize * cellSize * 3, YPosition * 1.67);
 
 const wallRef = useRef<THREE.Mesh>(null);
 const [selectedFrameId, setSelectedFrameId] = useState<string | null>(null);
+const [isDraggingFrame, setIsDraggingFrame] = useState(false);
 
   return (
     <section className={styles.designerWindow}>
@@ -75,6 +76,8 @@ const [selectedFrameId, setSelectedFrameId] = useState<string | null>(null);
               wallMesh={wallRef.current}
               selected={selectedFrameId === frame.id}
               onSelect={() => setSelectedFrameId(frame.id)}
+              onDragStart={() => setIsDraggingFrame(true)}
+              onDragEnd={() => setIsDraggingFrame(false)}
             />
           </group>
         ))}
@@ -82,7 +85,7 @@ const [selectedFrameId, setSelectedFrameId] = useState<string | null>(null);
         <OrbitControls 
           enablePan={false}
           enableZoom={true}
-          enableRotate={!selectedFrameId ? true : false} // Disable rotation when a frame is selected
+          enableRotate={isDraggingFrame ? false : true} // Disable rotation when a frame is selected
           minDistance={minDistanceZoom}
           maxDistance={maxDistanceZoom}
           maxPolarAngle={Math.PI / 2 - 0.1} // Prevent camera from going below floor

--- a/frontend/src/features/designer/scene-components/furniture/Frame.tsx
+++ b/frontend/src/features/designer/scene-components/furniture/Frame.tsx
@@ -12,6 +12,8 @@ type FrameProps = {
     wallMesh?: THREE.Mesh | null;
     selected?: boolean;
     onSelect?: () => void;
+    onDragStart?: () => void;
+    onDragEnd?: () => void;
 }
 
 export const Frame: React.FC<FrameProps> = ({
@@ -22,7 +24,9 @@ export const Frame: React.FC<FrameProps> = ({
     gridCellSize,
     wallMesh,
     selected = false,
-    onSelect
+    onSelect,
+    onDragStart,
+    onDragEnd
 }) => {
     const frameThickness = 3 * gridCellSize; // 3 cm thickness
     const groupRef = useRef<THREE.Group>(null);
@@ -104,6 +108,7 @@ export const Frame: React.FC<FrameProps> = ({
         }
     
         setIsDragging(true);
+        onDragStart?.();
         (e.target as HTMLElement).setPointerCapture(e.pointerId);
     };
 
@@ -149,6 +154,7 @@ export const Frame: React.FC<FrameProps> = ({
     const handlePointerUp = (e: ThreeEvent<PointerEvent>) => {
         if (isDragging) {
             setIsDragging(false);
+            onDragEnd?.();
             (e.target as HTMLElement).releasePointerCapture(e.pointerId);
         }
     };


### PR DESCRIPTION
Added a isDraggingFrame state in Canvas3D to know if a frame is being dragged or not and added a conditional operator as the enableRotate value. I didn't use the existing selectedFrameId as the condition because the user experience is smoother when the rotate orientation is only enabled while dragging.