### PR TITLE
Add calc from left corner and fix 4 cm offset

### DIFF
--- a/frontend/src/features/designer/scene-components/furniture/Frame.tsx
+++ b/frontend/src/features/designer/scene-components/furniture/Frame.tsx
@@ -88,7 +88,7 @@ export const Frame: React.FC<FrameProps> = ({
         const wallWidthInMeters = wallWidth * gridCellSize;
         const wallHeightInMeters = ceilingHeight * gridCellSize;
         
-        // Half dimensions of the frame (including thickness)
+        // Half dimensions of the frame
         const halfFrameWidth = frameWidth / 2; 
         const halfFrameHeight = frameHeight / 2;
         
@@ -105,7 +105,7 @@ export const Frame: React.FC<FrameProps> = ({
         const worldToLowerLeft = (worldPos: THREE.Vector3): { x: number; y: number } => {
             const wallWidthInMeters = wallWidth * gridCellSize;
             
-            // Calculate half dimensions of the ENTIRE frame (including thickness)
+            // Calculate half dimensions of the ENTIRE frame
             const halfTotalFrameWidth = frameWidth / 2;
             const halfTotalFrameHeight = frameHeight / 2;
             


### PR DESCRIPTION
Added a worldToLowerLeft function to get the cm placements with bottom-left corner instead of center of wall. Also fixed an old misstake in the process where we accidentally added frame thickness to the outer box instead of retracting it from the inner boxes. Making the frames 8cm too wide and high. 