### PR TITLE
Implemented save position in designData and updated moved frame position in saved designs

### DIFF
--- a/frontend/src/app/designer/[id]/page.tsx
+++ b/frontend/src/app/designer/[id]/page.tsx
@@ -25,6 +25,7 @@ export default function DesignerPage() {
     setFrameColor,
     setFrameImage,
     setFrameOrientation,
+    setFramePosition,
     setFrameSize,
     setFrames,
     setFurnitureColor,
@@ -101,6 +102,7 @@ export default function DesignerPage() {
         setFrameColor={setFrameColor}
         setFrameImage={setFrameImage}
         setFrameOrientation={setFrameOrientation}
+        setFramePosition={setFramePosition}
         setFrameSize={setFrameSize}
         setFurnitureColor={setFurnitureColor}
         setFurnitureDepth={setFurnitureDepth}

--- a/frontend/src/app/designer/page.tsx
+++ b/frontend/src/app/designer/page.tsx
@@ -20,6 +20,7 @@ export default function NewDesignPage() {
     setFrameColor,
     setFrameImage,
     setFrameOrientation,
+    setFramePosition,
     setFrameSize,
     setFrames,
     setFurnitureColor,
@@ -71,6 +72,7 @@ export default function NewDesignPage() {
         setFrameColor={setFrameColor}
         setFrameImage={setFrameImage}
         setFrameOrientation={setFrameOrientation}
+        setFramePosition={setFramePosition}
         setFrameSize={setFrameSize}
         setFurnitureColor={setFurnitureColor}
         setFurnitureDepth={setFurnitureDepth}

--- a/frontend/src/features/designer/Canvas3D/Canvas3D.tsx
+++ b/frontend/src/features/designer/Canvas3D/Canvas3D.tsx
@@ -24,10 +24,11 @@ interface Canvas3DProps {
   selectedFrameId?: string | null;
   onFrameSelect?: (frameId: string | null) => void;
   onFramePositionChange?: (frameId: string, position: THREE.Vector3) => void;
+  onFramePositionUpdate?: (index: number, position: [number, number, number]) => void;
   canvasRef?: React.RefObject<HTMLCanvasElement | null>;
 }
 
-export default function Canvas3D({ wallWidth, ceilingHeight, wallColor, flooring, furnitureColor, furnitureWidth, furnitureDepth, furnitureHeight, frames, selectedFrameId, onFrameSelect, onFramePositionChange, canvasRef } : Canvas3DProps) {
+export default function Canvas3D({ wallWidth, ceilingHeight, wallColor, flooring, furnitureColor, furnitureWidth, furnitureDepth, furnitureHeight, frames, selectedFrameId, onFrameSelect, onFramePositionUpdate, canvasRef } : Canvas3DProps) {
 
 const cellSize = 0.01; // 1 cm
 const floorSize = Math.max(wallWidth, 500);
@@ -47,6 +48,13 @@ const [internalSelectedFrameId, setInternalSelectedFrameId] = useState<string | 
 const currentSelectedFrameId = selectedFrameId !== undefined ? selectedFrameId : internalSelectedFrameId;
 const handleFrameSelect = onFrameSelect || setInternalSelectedFrameId;
 const [isDraggingFrame, setIsDraggingFrame] = useState(false);
+
+const handlePositionUpdate = (frameId: string, position: THREE.Vector3) => {
+  const frameIndex = frames.findIndex(f => f.id === frameId);
+  if (frameIndex !== -1 && onFramePositionUpdate) {
+    onFramePositionUpdate(frameIndex, [position.x, position.y, position.z]);
+  }
+};
 
   return (
     <section className={styles.designerWindow}>
@@ -90,24 +98,24 @@ const [isDraggingFrame, setIsDraggingFrame] = useState(false);
         <Sofa sofaColor={furnitureColor.sofa} sofaWidth={furnitureWidth} sofaDepth={furnitureDepth} sofaHeight={furnitureHeight} floorSize={floorSize} gridCellSize={cellSize} />
         {/* Render all frames */}
         {frames.map((frame) => (
-          <group key={frame.id} position={frame.position}>
-            <Frame 
-              frameColor={frame.frameColor}
-              frameSize={frame.frameSize}
-              frameOrientation={frame.frameOrientation}
-              imageUrl={frame.imageUrl}
-              floorSize={floorSize}
-              gridCellSize={cellSize}
-              wallMesh={wallRef.current}
-              wallWidth={wallWidth}
-              ceilingHeight={ceilingHeight}
-              selected={selectedFrameId === frame.id}
-              onSelect={() => handleFrameSelect(frame.id)}
-              onDragStart={() => setIsDraggingFrame(true)}
-              onDragEnd={() => setIsDraggingFrame(false)}
-              onPositionChange={(position) => onFramePositionChange?.(frame.id, position)}
-            />
-          </group>
+          <Frame 
+            key={frame.id}
+            frameColor={frame.frameColor}
+            frameSize={frame.frameSize}
+            frameOrientation={frame.frameOrientation}
+            imageUrl={frame.imageUrl}
+            floorSize={floorSize}
+            gridCellSize={cellSize}
+            wallMesh={wallRef.current}
+            wallWidth={wallWidth}
+            ceilingHeight={ceilingHeight}
+            selected={selectedFrameId === frame.id}
+            onSelect={() => handleFrameSelect(frame.id)}
+            onDragStart={() => setIsDraggingFrame(true)}
+            onDragEnd={() => setIsDraggingFrame(false)}
+            onPositionChange={(position) => handlePositionUpdate(frame.id, position)}
+            framePosition={frame.position}
+          />
         ))}
 
         <OrbitControls 

--- a/frontend/src/features/designer/DesignerWorkspace/DesignerWorkspace.tsx
+++ b/frontend/src/features/designer/DesignerWorkspace/DesignerWorkspace.tsx
@@ -33,6 +33,7 @@ interface DesignerWorkspaceProps {
     index: number,
     orientation: "portrait" | "landscape"
   ) => void;
+  setFramePosition: (index: number, position: [number, number, number]) => void;
   deleteFrame: (index: number) => void;
 }
 
@@ -56,6 +57,7 @@ export default function DesignerWorkspace({
   setFrameImage,
   setFrameSize,
   setFrameOrientation,
+  setFramePosition,
   deleteFrame,
 }: DesignerWorkspaceProps) {
   const [selectedFrameId, setSelectedFrameId] = useState<string | null>(null);
@@ -158,6 +160,7 @@ export default function DesignerWorkspace({
           frames={customDesign.frames}
           selectedFrameId={selectedFrameId}
           onFrameSelect={setSelectedFrameId}
+          onFramePositionUpdate={setFramePosition}
           canvasRef={canvasRef}
         />
       )}

--- a/frontend/src/features/designer/scene-components/furniture/Frame.tsx
+++ b/frontend/src/features/designer/scene-components/furniture/Frame.tsx
@@ -17,6 +17,7 @@ type FrameProps = {
     onSelect?: () => void;
     onDragStart?: () => void;
     onDragEnd?: () => void;
+    framePosition?: [number, number, number];
     onPositionChange?: (position: THREE.Vector3) => void;
 }
 
@@ -34,6 +35,7 @@ export const Frame: React.FC<FrameProps> = ({
     onSelect,
     onDragStart,
     onDragEnd,
+    framePosition = [0, 1.5, 0],
     onPositionChange
 }) => {
     const frameThickness = 4 * gridCellSize; // 4 cm thickness
@@ -42,6 +44,7 @@ export const Frame: React.FC<FrameProps> = ({
     const [position, setPosition] = useState({ x: 100, y: 150 });
     const dragOffset = useRef(new THREE.Vector3());
     const [ImageTexture, setImageTexture] = useState<THREE.Texture | null>(null);
+    const isInitialized = useRef(false); // To prevent initial clamping effect before first position set
     
     const { camera, gl, raycaster } = useThree();
 
@@ -128,7 +131,7 @@ export const Frame: React.FC<FrameProps> = ({
 
       // Effect to clamp frame position when wall dimensions change
       useEffect(() => {
-        if (groupRef.current) {
+        if (groupRef.current && isInitialized.current) {
             const currentPos = new THREE.Vector3();
             groupRef.current.getWorldPosition(currentPos);
             
@@ -156,6 +159,15 @@ export const Frame: React.FC<FrameProps> = ({
         }
     }, [wallWidth, ceilingHeight, frameWidth, frameHeight]);
 
+    // Initialize position from props
+    useEffect(() => {
+        console.log('Frame position effect running:', framePosition, 'Z:', frameZPlacement);
+        if (groupRef.current && framePosition) {
+            groupRef.current.position.set(framePosition[0], framePosition[1], frameZPlacement);
+            console.log('Set position to:', framePosition[0], framePosition[1], frameZPlacement);
+            isInitialized.current = true;
+        }
+    }, [framePosition, frameZPlacement]);
 
     
     // Helper function to snap to our 1x1cm grid
@@ -275,7 +287,6 @@ export const Frame: React.FC<FrameProps> = ({
 
     return (
         <group
-            position={[0, 0, frameZPlacement]}
             ref={groupRef}
             onPointerDown={handlePointerDown}
             onPointerMove={handlePointerMove}

--- a/frontend/src/features/designs/useCustomDesign.ts
+++ b/frontend/src/features/designs/useCustomDesign.ts
@@ -117,6 +117,10 @@ export function useCustomDesign(initialDesign?: Partial<CustomDesign>) {
     updateFrame(index, { frameOrientation: orientation });
   };
 
+  const setFramePosition = (index: number, framePosition: [number, number, number]) => {
+    updateFrame(index, { position: framePosition });
+  }
+
   const deleteFrame = (index: number) => {
     setCustomDesign((prev) => ({
       ...prev,
@@ -178,6 +182,7 @@ export function useCustomDesign(initialDesign?: Partial<CustomDesign>) {
     setFrameImage,
     setFrameSize,
     setFrameOrientation,
+    setFramePosition,
     deleteFrame,
     getSceneData,
     loadSceneData


### PR DESCRIPTION
So difficult to explain how I did this, hours and hours and one big commit...

First I added a setFramePosition helper function to useCustomDesign and exported it. 

Then I added that new helper to the DesignerWorkspace props and added it to the Canvas3D props, to follow our standard logic. Here I forgot to add the new DesignerWorkspace props to the pages where we actually use the component. That took an embarrassing amount of hours to realise..

Then in Canvas3D I added a function called handlePositionUpdate, the function looks up a frame by id and if it finds it, calls onFramePositionUpdate to update the frame's new position. I also had to remove the `<group>` tag because that parent somehow interfered with my local position logic in Frame.tsx, making the relationship between coordinates and position unclear?

In Frame.tsx is where the real mess begins.. I removed the position value in the `<group>` as it shouldn't be "hard-coded" into the component anyway. The logic for updating the position for the Frame.tsx file needed a useEffect, I thought it was correct but the frame blinked into the room on "add" and then disappeared. Turns out after some de-bugging that it ended up behind the sofa... The useEffect to clamp the frame ran before the initial random position occurred. So because of that I had to create a isInitialized useRef that checks if the useEffect for initializing is running. I also added a "check the isInitialized" in the if-statement in the clamp useEffect, all so it doesn't run unless we are finished initializing.  