### PR TITLE
Introduces allowNextNavigation() to useBlockNavigation hook

### DIFF
--- a/frontend/src/app/designer/page.tsx
+++ b/frontend/src/app/designer/page.tsx
@@ -37,9 +37,10 @@ export default function NewDesignPage() {
     deleteFrame,
     customDesign,
     hasUnsavedChanges,
+    markAsSaved
   } = useCustomDesign();
 
-  const { isAttemptingNavigation, proceedNavigation, cancelNavigation } =
+  const { isAttemptingNavigation, proceedNavigation, cancelNavigation, allowNextNavigation } =
     useBlockNavigation(hasUnsavedChanges);
 
   useUnsavedChangesWarning(hasUnsavedChanges);
@@ -66,6 +67,7 @@ export default function NewDesignPage() {
       console.log("About to create design with sceneData:", sceneData);
       console.log("Parsed:", JSON.parse(sceneData));
       if (newDesign) {
+        allowNextNavigation();
         router.push(`/designer/${newDesign.id}`);
       }
     } catch (error) {

--- a/frontend/src/lib/useBlockNavigation.tsx
+++ b/frontend/src/lib/useBlockNavigation.tsx
@@ -13,6 +13,7 @@ const useBlockNavigation = (
   const [nextRoute, setNextRoute] = useState<string | null>(null);
   const originalPushRef = useRef(router.push); // Store original router.push
   const lastLocationRef = useRef<string | null>(null); // Store last visited route    // Check if navigation is allowed
+  const bypassNextNavigationRef = useRef<boolean>(false); // A ref to allow us to byPass the hook when necessary (for example when saving a design in the designer reroutes us to the new designer[id] page)
   const canNavigate = (url: string) => {
     const { pathname } = new URL(url, window.location.origin);
     return allowedRoutes.some(
@@ -21,7 +22,15 @@ const useBlockNavigation = (
   };
   useEffect(() => {
     const handleNavigation = (url: string) => {
-      if (!shouldBlock || canNavigate(url) || url === pathname) {
+      if (
+        !shouldBlock ||
+        canNavigate(url) ||
+        url === pathname ||
+        bypassNextNavigationRef.current
+      ) {
+        if (bypassNextNavigationRef.current) {
+          bypassNextNavigationRef.current = false;
+        }
         originalPushRef.current(url);
         return;
       }
@@ -75,6 +84,15 @@ const useBlockNavigation = (
     setIsAttemptingNavigation(false);
     setNextRoute(null);
   };
-  return { isAttemptingNavigation, proceedNavigation, cancelNavigation };
+
+  const allowNextNavigation = () => {
+    bypassNextNavigationRef.current = true;
+  };
+  return {
+    isAttemptingNavigation,
+    proceedNavigation,
+    cancelNavigation,
+    allowNextNavigation,
+  };
 };
 export default useBlockNavigation;


### PR DESCRIPTION
Introduces a bypassNavigation ref to use in the useblockNavigation to allow designs to be saved in the designer and rerouted to designer[id] page without being prompted whether the use wants to leave the page.