### PR TITLE
Add function to preload textures before canvas render

### DIFF
--- a/frontend/src/features/designer/Canvas3D/Canvas3D.tsx
+++ b/frontend/src/features/designer/Canvas3D/Canvas3D.tsx
@@ -1,5 +1,5 @@
 import styles from "./Canvas3D.module.css";
-import React, { useRef, useState } from 'react';
+import React, { useRef, useState, useEffect } from 'react';
 import * as THREE from 'three';
 import { Canvas } from '@react-three/fiber';
 import { OrbitControls } from '@react-three/drei';
@@ -11,6 +11,7 @@ import { Sofa } from "../scene-components/furniture/Sofa";
 import { FurnitureColor } from "../FurnitureForm/FurnitureForm";
 import { Frame } from "../scene-components/furniture/Frame";
 import { FrameData } from "../FrameForm/FrameForm";
+import { preloadTextures } from "@/lib/preloadTextures";
 
 interface Canvas3DProps {
   wallWidth: number;
@@ -37,6 +38,10 @@ interface Canvas3DProps {
 }
 
 export default function Canvas3D({ wallWidth, ceilingHeight, wallColor, flooring, furnitureColor, furnitureWidth, furnitureDepth, furnitureHeight, frames, selectedFrameId, onFrameSelect, onFramePositionUpdate, canvasRef, occupiedPositions } : Canvas3DProps) {
+
+useEffect(() => {
+    preloadTextures();
+  }, []);
 
 const cellSize = 0.01; // 1 cm
 const floorSize = Math.max(wallWidth, 300);

--- a/frontend/src/features/designer/scene-components/structural/Floor.tsx
+++ b/frontend/src/features/designer/scene-components/structural/Floor.tsx
@@ -1,39 +1,24 @@
 import React from 'react';
-import * as THREE from 'three';
-import { useTexture } from "@react-three/drei";
+import { getFloorMaterial } from '@/lib/preloadTextures';
 
 type FloorProps = {
   flooring: string;
-    gridSize: number;
-    gridCellSize: number;
-}
+  gridSize: number;
+  gridCellSize: number;
+};
 
-
-export const Floor: React.FC<FloorProps> = ({flooring, gridSize, gridCellSize}) => {
-    const floorSize = gridSize * gridCellSize; // convert cm to Three.js units
-
-      const textures = useTexture({
-        map: `/3D-textures/${flooring}/albedo.jpg`,
-        normalMap: `/3D-textures/${flooring}/normal.jpg`,
-        roughnessMap: `/3D-textures/${flooring}/roughness.jpg`,
-      })
-    
-      // Repeat pattern across the floor
-      Object.values(textures).forEach(tex => {
-        tex.wrapS = tex.wrapT = THREE.RepeatWrapping
-        tex.repeat.set(1, 1)
-      })
+export const Floor: React.FC<FloorProps> = ({ flooring, gridSize, gridCellSize }) => {
+  const floorSize = gridSize * gridCellSize; // convert cm to Three.js units
+  const material = getFloorMaterial(flooring);
 
   return (
-    <mesh 
-      rotation={[-Math.PI / 2, 0, 0]} 
+    <mesh
+      rotation={[-Math.PI / 2, 0, 0]}
       position={[0, 0, 0]}
       receiveShadow
+      material={material}
     >
       <planeGeometry args={[floorSize, floorSize]} />
-      <meshStandardMaterial 
-        {...textures}
-      />
     </mesh>
   );
 };

--- a/frontend/src/lib/preloadTextures.ts
+++ b/frontend/src/lib/preloadTextures.ts
@@ -1,0 +1,57 @@
+import * as THREE from 'three';
+
+const floorList = [
+  'birch-floor-parquet',
+  'birch-floor-herringbone',
+  'walnut-floor-parquet',
+  'walnut-floor-herringbone',
+];
+
+const floorMaterials: Record<string, THREE.MeshStandardMaterial> = {};
+let texturesLoaded = false;
+
+export function preloadTextures() {
+  if (texturesLoaded) return Promise.resolve();
+
+  const loader = new THREE.TextureLoader();
+  const promises: Promise<void>[] = [];
+
+  floorList.forEach((flooring) => {
+    const promise = Promise.all([
+      loader.loadAsync(`/3D-textures/${flooring}/albedo.jpg`),
+      loader.loadAsync(`/3D-textures/${flooring}/normal.jpg`),
+      loader.loadAsync(`/3D-textures/${flooring}/roughness.jpg`),
+    ]).then(([map, normalMap, roughnessMap]) => {
+      // Setup texture properties
+      [map, normalMap, roughnessMap].forEach((tex) => {
+        tex.wrapS = tex.wrapT = THREE.RepeatWrapping;
+        tex.repeat.set(1, 1);
+      });
+
+      map.colorSpace = THREE.SRGBColorSpace;
+      normalMap.colorSpace = THREE.NoColorSpace;
+      roughnessMap.colorSpace = THREE.NoColorSpace;
+
+      floorMaterials[flooring] = new THREE.MeshStandardMaterial({
+        map,
+        normalMap,
+        roughnessMap,
+      });
+    });
+
+    promises.push(promise);
+  });
+
+  return Promise.all(promises).then(() => {
+    texturesLoaded = true;
+  });
+}
+
+export function getFloorMaterial(flooring: string) {
+  const mat = floorMaterials[flooring];
+  if (!mat) {
+    console.warn(`Flooring material "${flooring}" not preloaded.`);
+    return new THREE.MeshStandardMaterial();
+  }
+  return mat.clone();
+}


### PR DESCRIPTION
After a long fight with THREE compatibility issues we got a solution. This utility and useEffect prevents texture blinking on first floor material change by preloading all floor textures using THREE.TextureLoader.